### PR TITLE
Add KPI counts to dashboard and DAO helpers

### DIFF
--- a/src/main/java/com/pahanaedu/pahanasuite/dao/BillDAO.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/BillDAO.java
@@ -2,6 +2,7 @@ package com.pahanaedu.pahanasuite.dao;
 
 import com.pahanaedu.pahanasuite.models.Bill;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface BillDAO {
@@ -20,4 +21,7 @@ public interface BillDAO {
 
     /** Returns bill headers only (no lines) for simple listings. */
     List<Bill> findAll();
+
+    /** Counts bills issued between [from, to). */
+    int countIssuedBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/pahanaedu/pahanasuite/dao/CustomerDAO.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/CustomerDAO.java
@@ -11,4 +11,7 @@ public interface CustomerDAO {
     Customer createCustomer(Customer customer);
     boolean updateCustomer(Customer customer);
     boolean deleteCustomer(int id);
+
+    /** Counts all customers. */
+    int countAll();
 }

--- a/src/main/java/com/pahanaedu/pahanasuite/dao/ItemDAO.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/ItemDAO.java
@@ -14,4 +14,7 @@ public interface ItemDAO {
 
     /** Add or remove stock in one atomic statement; refuses to go below 0. */
     boolean adjustStock(int id, int delta);
+
+    /** Counts items whose stock is below the given threshold. */
+    int countLowStock(int threshold);
 }

--- a/src/main/java/com/pahanaedu/pahanasuite/dao/impl/BillDAOImpl.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/impl/BillDAOImpl.java
@@ -7,6 +7,7 @@ import com.pahanaedu.pahanasuite.models.BillLine;
 import com.pahanaedu.pahanasuite.models.BillStatus;
 
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,8 @@ public class BillDAOImpl implements BillDAO {
 
     private static final String DELETE_LINES = "DELETE FROM bill_lines WHERE bill_id = ?";
     private static final String DELETE_BILL  = "DELETE FROM bills WHERE id = ?";
+    private static final String COUNT_ISSUED_BETWEEN =
+            "SELECT COUNT(*) FROM bills WHERE issued_at >= ? AND issued_at < ?";
 
     @Override
     public Bill createBill(Bill bill) {
@@ -218,6 +221,23 @@ public class BillDAOImpl implements BillDAO {
             e.printStackTrace();
         }
         return list;
+    }
+
+    @Override
+    public int countIssuedBetween(LocalDateTime from, LocalDateTime to) {
+        try (Connection conn = DBConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(COUNT_ISSUED_BETWEEN)) {
+
+            ps.setTimestamp(1, ts(from));
+            ps.setTimestamp(2, ts(to));
+
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getInt(1) : 0;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
     }
 
     private static Bill mapBill(ResultSet rs) throws SQLException {

--- a/src/main/java/com/pahanaedu/pahanasuite/dao/impl/CustomerDAOImpl.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/impl/CustomerDAOImpl.java
@@ -22,6 +22,8 @@ public class CustomerDAOImpl implements CustomerDAO {
             "UPDATE customers SET account_number = ?, name = ?, address = ?, telephone = ?, units_consumed = ? WHERE id = ?";
     private static final String DELETE_CUSTOMER =
             "DELETE FROM customers WHERE id = ?";
+    private static final String COUNT_ALL =
+            "SELECT COUNT(*) FROM customers";
 
     @Override
     public Customer findById(int id) {
@@ -121,6 +123,19 @@ public class CustomerDAOImpl implements CustomerDAO {
             e.printStackTrace();
         }
         return false;
+    }
+
+    @Override
+    public int countAll() {
+        try (Connection conn = DBConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = ps.executeQuery()) {
+
+            return rs.next() ? rs.getInt(1) : 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
     }
 
     // -- helpers --

--- a/src/main/java/com/pahanaedu/pahanasuite/dao/impl/ItemDAOImpl.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/dao/impl/ItemDAOImpl.java
@@ -35,6 +35,8 @@ public class ItemDAOImpl implements ItemDAO {
 
     private static final String DELETE_ITEM =
             "DELETE FROM items WHERE id=?";
+    private static final String COUNT_LOW_STOCK =
+            "SELECT COUNT(*) FROM items WHERE stock_qty < ?";
 
     // MySQL atomic stock update, prevents going negative
     private static final String ADJUST_STOCK =
@@ -188,6 +190,20 @@ public class ItemDAOImpl implements ItemDAO {
         } catch (Exception e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    @Override
+    public int countLowStock(int threshold) {
+        try (Connection c = DBConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(COUNT_LOW_STOCK)) {
+            ps.setInt(1, threshold);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getInt(1) : 0;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
         }
     }
 

--- a/src/main/java/com/pahanaedu/pahanasuite/services/CustomerService.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/services/CustomerService.java
@@ -105,6 +105,11 @@ public class CustomerService {
         return customerDAO.deleteCustomer(id);
     }
 
+    /** Returns total number of customers. */
+    public int countAll() {
+        return customerDAO.countAll();
+    }
+
     // --- helpers ---
 
     private static String trim(String s) { return s == null ? null : s.trim(); }

--- a/src/main/java/com/pahanaedu/pahanasuite/services/ItemService.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/services/ItemService.java
@@ -130,6 +130,11 @@ public class ItemService {
         return itemDAO.adjustStock(id, delta);
     }
 
+    /** Returns count of items with stock below threshold. */
+    public int countLowStock(int threshold) {
+        return itemDAO.countLowStock(threshold);
+    }
+
     // ---------- helpers ----------
     private static boolean isValidPrice(BigDecimal p) {
         return p != null && p.compareTo(BigDecimal.ZERO) >= 0;

--- a/src/main/java/com/pahanaedu/pahanasuite/web/DashboardServlet.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/web/DashboardServlet.java
@@ -20,6 +20,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @WebServlet("/dashboard/*")
 public class DashboardServlet extends HttpServlet {
@@ -70,7 +72,22 @@ public class DashboardServlet extends HttpServlet {
         section = validateSectionAccess(section, role);
 
         // Load data needed for the section
-        if ("users".equalsIgnoreCase(section)) {
+        if ("overview".equalsIgnoreCase(section)) {
+            LocalDate today = LocalDate.now();
+            LocalDateTime startOfDay = today.atStartOfDay();
+            LocalDateTime startOfTomorrow = startOfDay.plusDays(1);
+            LocalDateTime startOfMonth = today.withDayOfMonth(1).atStartOfDay();
+
+            int daily = billDAO.countIssuedBetween(startOfDay, startOfTomorrow);
+            int monthly = billDAO.countIssuedBetween(startOfMonth, LocalDateTime.now());
+            int customers = customerService.countAll();
+            int lowStock = itemService.countLowStock(5);
+
+            req.setAttribute("kpiDailySales", daily);
+            req.setAttribute("kpiMonthlySales", monthly);
+            req.setAttribute("kpiCustomers", customers);
+            req.setAttribute("kpiLowStockItems", lowStock);
+        } else if ("users".equalsIgnoreCase(section)) {
             req.setAttribute("users", userService.listAll());
         } else if ("customers".equalsIgnoreCase(section)) {
             req.setAttribute("customers", customerService.listAll());

--- a/src/main/webapp/WEB-INF/views/dashboard/overview.jsp
+++ b/src/main/webapp/WEB-INF/views/dashboard/overview.jsp
@@ -1,16 +1,4 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%
-    // Optional: placeholders if backend attributes are not set yet
-    Integer kpiDailySales      = (Integer) request.getAttribute("kpiDailySales");
-    Integer kpiMonthlySales    = (Integer) request.getAttribute("kpiMonthlySales");
-    Integer kpiCustomers       = (Integer) request.getAttribute("kpiCustomers");
-    Integer kpiLowStockItems   = (Integer) request.getAttribute("kpiLowStockItems");
-
-    if (kpiDailySales == null)    kpiDailySales = 42;        // TODO replace with real value
-    if (kpiMonthlySales == null)  kpiMonthlySales = 1234;    // TODO replace
-    if (kpiCustomers == null)     kpiCustomers = 318;        // TODO replace
-    if (kpiLowStockItems == null) kpiLowStockItems = 7;      // TODO replace
-%>
 
 <section class="section">
     <h2 class="section-title">Overview</h2>
@@ -19,22 +7,22 @@
     <div class="kpi-grid">
         <div class="kpi-card">
             <div class="kpi-label">Today’s Bills</div>
-            <div class="kpi-value"><%= kpiDailySales %></div>
+            <div class="kpi-value"><%= request.getAttribute("kpiDailySales") == null ? 0 : request.getAttribute("kpiDailySales") %></div>
             <div class="kpi-foot"><a href="${pageContext.request.contextPath}/dashboard/sales">Open Billing</a></div>
         </div>
         <div class="kpi-card">
             <div class="kpi-label">Bills this Month</div>
-            <div class="kpi-value"><%= kpiMonthlySales %></div>
+            <div class="kpi-value"><%= request.getAttribute("kpiMonthlySales") == null ? 0 : request.getAttribute("kpiMonthlySales") %></div>
             <div class="kpi-foot"><a href="#">View report</a></div>
         </div>
         <div class="kpi-card">
             <div class="kpi-label">Total Customers</div>
-            <div class="kpi-value"><%= kpiCustomers %></div>
+            <div class="kpi-value"><%= request.getAttribute("kpiCustomers") == null ? 0 : request.getAttribute("kpiCustomers") %></div>
             <div class="kpi-foot"><a href="${pageContext.request.contextPath}/dashboard/customers">Manage customers</a></div>
         </div>
         <div class="kpi-card kpi-warn">
             <div class="kpi-label">Low‑stock Items</div>
-            <div class="kpi-value"><%= kpiLowStockItems %></div>
+            <div class="kpi-value"><%= request.getAttribute("kpiLowStockItems") == null ? 0 : request.getAttribute("kpiLowStockItems") %></div>
             <div class="kpi-foot"><a href="${pageContext.request.contextPath}/dashboard/sales">Review items</a></div>
         </div>
     </div>

--- a/src/test/java/com/pahanaedu/pahanasuite/web/DashboardServletTest.java
+++ b/src/test/java/com/pahanaedu/pahanasuite/web/DashboardServletTest.java
@@ -1,6 +1,9 @@
 package com.pahanaedu.pahanasuite.web;
 
 import com.pahanaedu.pahanasuite.models.User;
+import com.pahanaedu.pahanasuite.dao.BillDAO;
+import com.pahanaedu.pahanasuite.services.CustomerService;
+import com.pahanaedu.pahanasuite.services.ItemService;
 import com.pahanaedu.pahanasuite.services.UserService;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.*;
@@ -15,14 +18,31 @@ public class DashboardServletTest {
 
     private DashboardServlet servlet;
     private UserService userService;
+    private CustomerService customerService;
+    private ItemService itemService;
+    private BillDAO billDAO;
 
     @BeforeEach
     void setup() throws Exception {
         servlet = new DashboardServlet();
         userService = mock(UserService.class);
-        Field f = DashboardServlet.class.getDeclaredField("userService");
+        customerService = mock(CustomerService.class);
+        itemService = mock(ItemService.class);
+        billDAO = mock(BillDAO.class);
+
+        Field f;
+        f = DashboardServlet.class.getDeclaredField("userService");
         f.setAccessible(true);
         f.set(servlet, userService);
+        f = DashboardServlet.class.getDeclaredField("customerService");
+        f.setAccessible(true);
+        f.set(servlet, customerService);
+        f = DashboardServlet.class.getDeclaredField("itemService");
+        f.setAccessible(true);
+        f.set(servlet, itemService);
+        f = DashboardServlet.class.getDeclaredField("billDAO");
+        f.setAccessible(true);
+        f.set(servlet, billDAO);
     }
 
     @Test
@@ -60,5 +80,35 @@ public class DashboardServletTest {
         verify(req).setAttribute("currentSection", "overview");
         verify(req).setAttribute("hasSidebar", true);
         verify(rd).forward(req, resp);
+    }
+
+    @Test
+    void testOverviewKpisAreSetForAdmin() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+        RequestDispatcher rd = mock(RequestDispatcher.class);
+
+        User user = new User(1, "alice", null, "admin");
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("isLoggedIn")).thenReturn(true);
+        when(session.getAttribute("user")).thenReturn(user);
+        when(req.getRequestDispatcher("/dashboard.jsp")).thenReturn(rd);
+        when(req.getContextPath()).thenReturn("");
+        when(req.getPathInfo()).thenReturn("/overview");
+
+        when(billDAO.countIssuedBetween(any(), any())).thenReturn(5, 20);
+        when(customerService.countAll()).thenReturn(100);
+        when(itemService.countLowStock(anyInt())).thenReturn(4);
+
+        servlet.doGet(req, resp);
+
+        verify(req).setAttribute("kpiDailySales", 5);
+        verify(req).setAttribute("kpiMonthlySales", 20);
+        verify(req).setAttribute("kpiCustomers", 100);
+        verify(req).setAttribute("kpiLowStockItems", 4);
+        verify(itemService).countLowStock(5);
+        verify(billDAO, times(2)).countIssuedBetween(any(), any());
     }
 }


### PR DESCRIPTION
## Summary
- support counting bills in BillDAO/impl
- expose total customers and low stock counts through new DAO and service methods
- populate dashboard overview KPIs with real data
- clean up overview.jsp placeholders and extend servlet tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48fe4aef08326b6a452631db03d00