### PR TITLE
Align dashboard overview and settings panels

### DIFF
--- a/src/main/webapp/WEB-INF/views/dashboard/overview.jsp
+++ b/src/main/webapp/WEB-INF/views/dashboard/overview.jsp
@@ -1,8 +1,16 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.util.*,com.pahanaedu.pahanasuite.models.Bill,com.pahanaedu.pahanasuite.models.Item" %>
 
-<section class="section">
-    <h2 class="section-title">Overview</h2>
+<section class="section panel-section">
+    <header class="panel-head">
+        <h2 class="section-title">Overview</h2>
+        <div class="quick-actions">
+            <a class="btn btn-accent" href="${pageContext.request.contextPath}/dashboard/sales">New Bill</a>
+            <a class="btn" href="${pageContext.request.contextPath}/dashboard/customers">New Customer</a>
+            <a class="btn" href="${pageContext.request.contextPath}/dashboard/users">Add User</a>
+            <a class="btn" href="${pageContext.request.contextPath}/dashboard/settings">Settings</a>
+        </div>
+    </header>
 
     <!-- KPI cards -->
     <div class="kpi-grid">
@@ -28,14 +36,6 @@
         </div>
     </div>
 
-    <!-- Quick actions -->
-    <div class="quick-actions">
-        <a class="btn btn-accent" href="${pageContext.request.contextPath}/dashboard/sales">New Bill</a>
-        <a class="btn" href="${pageContext.request.contextPath}/dashboard/customers">New Customer</a>
-        <a class="btn" href="${pageContext.request.contextPath}/dashboard/users">Add User</a>
-        <a class="btn" href="${pageContext.request.contextPath}/dashboard/settings">Settings</a>
-    </div>
-
     <%
         @SuppressWarnings("unchecked")
         List<Bill> recentBills = (List<Bill>) request.getAttribute("recentBills");
@@ -43,48 +43,50 @@
         java.time.format.DateTimeFormatter tFmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm");
     %>
 
-    <div class="panel">
+    <div class="panel flex-panel">
         <div class="panel-head">
             <h3>Recent Bills</h3>
         </div>
-        <table class="data-table">
-            <thead>
-            <tr>
-                <th>Time</th>
-                <th>Bill No.</th>
-                <th>User</th>
-                <th>Total</th>
-            </tr>
-            </thead>
-            <tbody>
-            <%
-                if (recentBills.isEmpty()) {
-            %>
-            <tr><td colspan="4">No recent bills.</td></tr>
-            <%
-                } else {
-                    for (Bill b : recentBills) {
-                        String issuer;
-                        try {
-                            java.lang.reflect.Method m = b.getClass().getMethod("getIssuedBy");
-                            Object val = m.invoke(b);
-                            issuer = val == null ? "—" : String.valueOf(val);
-                        } catch (Exception e) {
-                            issuer = "—";
+        <div class="scroll-wrap">
+            <table class="data-table">
+                <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>Bill No.</th>
+                    <th>User</th>
+                    <th>Total</th>
+                </tr>
+                </thead>
+                <tbody>
+                <%
+                    if (recentBills.isEmpty()) {
+                %>
+                <tr><td colspan="4">No recent bills.</td></tr>
+                <%
+                    } else {
+                        for (Bill b : recentBills) {
+                            String issuer;
+                            try {
+                                java.lang.reflect.Method m = b.getClass().getMethod("getIssuedBy");
+                                Object val = m.invoke(b);
+                                issuer = val == null ? "—" : String.valueOf(val);
+                            } catch (Exception e) {
+                                issuer = "—";
+                            }
+                %>
+                <tr>
+                    <td><%= b.getIssuedAt()==null? "" : b.getIssuedAt().format(tFmt) %></td>
+                    <td><%= b.getBillNo()==null? ("#" + b.getId()) : b.getBillNo() %></td>
+                    <td><%= issuer %></td>
+                    <td>LKR <%= b.getTotal()==null? "0.00" : String.format("%,.2f", b.getTotal()) %></td>
+                </tr>
+                <%
                         }
-            %>
-            <tr>
-                <td><%= b.getIssuedAt()==null? "" : b.getIssuedAt().format(tFmt) %></td>
-                <td><%= b.getBillNo()==null? ("#" + b.getId()) : b.getBillNo() %></td>
-                <td><%= issuer %></td>
-                <td>LKR <%= b.getTotal()==null? "0.00" : String.format("%,.2f", b.getTotal()) %></td>
-            </tr>
-            <%
                     }
-                }
-            %>
-            </tbody>
-        </table>
+                %>
+                </tbody>
+            </table>
+        </div>
     </div>
 
     <%
@@ -94,29 +96,31 @@
         Integer lowStockCount = (Integer) request.getAttribute("lowStockCount");
         if (lowStockCount == null) lowStockCount = lowStockItems.size();
     %>
-    <div class="panel">
+    <div class="panel flex-panel">
         <div class="panel-head">
             <h3>Alerts</h3>
         </div>
-        <ul class="alert-list">
-            <%
-                if (lowStockItems.isEmpty()) {
-            %>
-            <li class="alert info">No items below reorder level.</li>
-            <%
-                } else {
-                    for (Item it : lowStockItems) {
-            %>
-            <li class="alert warn"><%= it.getName() %> is below reorder level.</li>
-            <%
+        <div class="scroll-wrap">
+            <ul class="alert-list">
+                <%
+                    if (lowStockItems.isEmpty()) {
+                %>
+                <li class="alert info">No items below reorder level.</li>
+                <%
+                    } else {
+                        for (Item it : lowStockItems) {
+                %>
+                <li class="alert warn"><%= it.getName() %> is below reorder level.</li>
+                <%
+                        }
+                        if (lowStockCount > lowStockItems.size()) {
+                %>
+                <li class="alert info"><a href="${pageContext.request.contextPath}/dashboard/items">View all low-stock items</a></li>
+                <%
+                        }
                     }
-                    if (lowStockCount > lowStockItems.size()) {
-            %>
-            <li class="alert info"><a href="${pageContext.request.contextPath}/dashboard/items">View all low-stock items</a></li>
-            <%
-                    }
-                }
-            %>
-        </ul>
+                %>
+            </ul>
+        </div>
     </div>
 </section>

--- a/src/main/webapp/WEB-INF/views/dashboard/settings.jsp
+++ b/src/main/webapp/WEB-INF/views/dashboard/settings.jsp
@@ -1,5 +1,9 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
-<section>
-    <h2>Settings</h2>
-    <p>Configuration options will appear here.</p>
+<section class="section panel-section">
+    <div class="panel flex-panel">
+        <div class="panel-head">
+            <h2 class="section-title">Settings</h2>
+        </div>
+        <p>Configuration options will appear here.</p>
+    </div>
 </section>


### PR DESCRIPTION
## Summary
- Apply shared panel layout and quick-action header to dashboard overview.
- Wrap recent bills and alert listings in `.scroll-wrap` for overflow handling.
- Convert settings page into shared panel layout for consistent non-scrolling design.

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9f2a7b08326b60776681d3edb5d