### PR TITLE
Fix sales dashboard scrolling to stay within viewport

### DIFF
--- a/src/main/webapp/WEB-INF/views/dashboard/sales.jsp
+++ b/src/main/webapp/WEB-INF/views/dashboard/sales.jsp
@@ -37,7 +37,7 @@
         --border-light: #f3f4f6;
         --border-focus: #3b82f6;
         --muted: #6b7280;
-        --panel-height: 78vh;
+        --panel-height: calc(100vh - 4rem - 6rem); /* viewport minus header and progress bar */
         --primary: #2563eb;
         --primary-dark: #1d4ed8;
         --success: #059669;

--- a/src/main/webapp/css/dashboard.css
+++ b/src/main/webapp/css/dashboard.css
@@ -23,7 +23,6 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100dvh; /* mobile-safe full height */
-    padding-bottom: 4rem; /* space for fixed footer */
     line-height: 1.5;
 }
 
@@ -121,7 +120,8 @@ body {
 .main-content {
     background-color: var(--light);
     padding: 1.5rem; /* more spacious */
-    overflow: auto;
+    margin-bottom: 4rem; /* space for fixed footer */
+    overflow: hidden; /* only inner panels scroll */
 }
 
 .content-wrapper {


### PR DESCRIPTION
## Summary
- Move footer spacing from `body` padding to `.main-content` margin and hide overflow so only panels scroll
- Compute dashboard panel height using viewport minus header and progress bar to avoid page scrollbar

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab5a661c8326a3901992872d2f0d