### PR TITLE
Add bills listing and actions to dashboard

### DIFF
--- a/src/main/java/com/pahanaedu/pahanasuite/web/BillsServlet.java
+++ b/src/main/java/com/pahanaedu/pahanasuite/web/BillsServlet.java
@@ -1,0 +1,112 @@
+package com.pahanaedu.pahanasuite.web;
+
+import com.pahanaedu.pahanasuite.dao.BillDAO;
+import com.pahanaedu.pahanasuite.dao.impl.BillDAOImpl;
+import com.pahanaedu.pahanasuite.models.Bill;
+import com.pahanaedu.pahanasuite.models.BillStatus;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+import java.util.List;
+
+@WebServlet(urlPatterns = "/dashboard/bills")
+public class BillsServlet extends HttpServlet {
+
+    private BillDAO billDAO;
+
+    @Override
+    public void init() {
+        billDAO = new BillDAOImpl();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession(false);
+        if (session == null || !Boolean.TRUE.equals(session.getAttribute("isLoggedIn"))) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        // Load all bill headers for listing
+        List<Bill> bills = billDAO.findAll();
+        req.setAttribute("bills", bills);
+
+        // If ?id= provided, load bill details
+        int id = parseInt(req.getParameter("id"));
+        if (id > 0) {
+            Bill b = billDAO.findById(id);
+            if (b != null) req.setAttribute("selectedBill", b);
+        }
+
+        // dashboard wrapper expectations
+        req.setAttribute("currentSection", "bills");
+        req.setAttribute("hasSidebar", Boolean.TRUE);
+        Object role = session.getAttribute("userRole");
+        Object user = session.getAttribute("username");
+        if (role != null) req.setAttribute("userRole", role);
+        if (user != null) req.setAttribute("username", user);
+
+        Object flash = session.getAttribute("flash");
+        if (flash != null) {
+            req.setAttribute("flash", String.valueOf(flash));
+            session.removeAttribute("flash");
+        }
+
+        req.getRequestDispatcher("/dashboard.jsp").forward(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        HttpSession session = req.getSession(false);
+        if (session == null || !Boolean.TRUE.equals(session.getAttribute("isLoggedIn"))) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        String role = String.valueOf(session.getAttribute("userRole"));
+        boolean canWrite = "admin".equalsIgnoreCase(role) || "manager".equalsIgnoreCase(role);
+        if (!canWrite) {
+            resp.sendRedirect(req.getContextPath() + "/dashboard/bills?err=forbidden");
+            return;
+        }
+
+        String action = trim(req.getParameter("action"));
+        int id = parseInt(req.getParameter("id"));
+
+        switch (action == null ? "" : action) {
+            case "delete" -> {
+                if (id > 0 && billDAO.deleteBill(id)) {
+                    session.setAttribute("flash", "Bill deleted.");
+                } else {
+                    session.setAttribute("flash", "Delete failed.");
+                }
+            }
+            case "markPaid" -> {
+                if (id > 0) {
+                    Bill bill = billDAO.findById(id);
+                    if (bill != null) {
+                        bill.setStatus(BillStatus.PAID);
+                        boolean ok = billDAO.updateBill(bill);
+                        session.setAttribute("flash", ok ? "Bill marked as paid." : "Operation failed.");
+                    } else {
+                        session.setAttribute("flash", "Bill not found.");
+                    }
+                }
+            }
+            default -> {
+                // ignore unknown
+            }
+        }
+
+        resp.sendRedirect(req.getContextPath() + "/dashboard/bills");
+    }
+
+    private static String trim(String s) { return s == null ? null : s.trim(); }
+    private static int parseInt(String s) { try { return Integer.parseInt(s); } catch (Exception e) { return -1; } }
+}

--- a/src/main/webapp/WEB-INF/views/components/navigation.jsp
+++ b/src/main/webapp/WEB-INF/views/components/navigation.jsp
@@ -14,6 +14,8 @@
                href="${pageContext.request.contextPath}/dashboard/items">Items</a></li>
         <li><a class="<%= "sales".equals(currentSection) ? "active" : "" %>"
                href="${pageContext.request.contextPath}/dashboard/sales">Sales</a></li>
+        <li><a class="<%= "bills".equals(currentSection) ? "active" : "" %>"
+               href="${pageContext.request.contextPath}/dashboard/bills">Bills</a></li>
         <li><a class="<%= "settings".equals(currentSection) ? "active" : "" %>"
                href="${pageContext.request.contextPath}/dashboard/settings">Settings</a></li>
     </ul>

--- a/src/main/webapp/WEB-INF/views/dashboard/bills.jsp
+++ b/src/main/webapp/WEB-INF/views/dashboard/bills.jsp
@@ -1,0 +1,112 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="java.util.*,com.pahanaedu.pahanasuite.models.Bill,com.pahanaedu.pahanasuite.models.BillLine" %>
+<%
+    String ctx = request.getContextPath();
+    @SuppressWarnings("unchecked")
+    List<Bill> bills = (List<Bill>) request.getAttribute("bills");
+    if (bills == null) bills = java.util.Collections.emptyList();
+    Bill selected = (Bill) request.getAttribute("selectedBill");
+    String flash = (String) request.getAttribute("flash");
+    String role = (String) request.getAttribute("userRole");
+    boolean canWrite = role != null && (role.equalsIgnoreCase("admin") || role.equalsIgnoreCase("manager"));
+%>
+
+<section class="section panel-section">
+    <header class="panel-head">
+        <h2 class="section-title">Bills</h2>
+    </header>
+
+    <% if (flash != null && !flash.isBlank()) { %>
+    <div class="panel" style="margin-bottom:1rem;background:#ecfdf5;border-color:#a7f3d0;">
+        <div style="color:#065f46;"> <%= flash %> </div>
+    </div>
+    <% } %>
+
+    <div class="panel flex-panel">
+        <div class="scroll-wrap">
+            <table class="data-table">
+                <thead>
+                <tr>
+                    <th style="width:80px;">ID</th>
+                    <th style="width:120px;">Bill No</th>
+                    <th style="width:120px;">Customer</th>
+                    <th style="width:160px;">Issued At</th>
+                    <th style="width:100px;">Status</th>
+                    <th style="width:240px;">Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                <% if (bills.isEmpty()) { %>
+                <tr><td colspan="6">No bills found.</td></tr>
+                <% } else { for (Bill b : bills) { %>
+                <tr>
+                    <td><%= b.getId() %></td>
+                    <td><%= b.getBillNo() %></td>
+                    <td><%= b.getCustomerId() %></td>
+                    <td><%= b.getIssuedAt() %></td>
+                    <td><%= b.getStatus() %></td>
+                    <td>
+                        <a class="btn" href="<%=ctx%>/dashboard/bills?id=<%=b.getId()%>">View</a>
+                        <% if (canWrite) { %>
+                        <form action="<%=ctx%>/dashboard/bills" method="post" style="display:inline" onsubmit="return confirm('Delete bill <%=b.getBillNo()%>?');">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<%=b.getId()%>">
+                            <button class="btn" type="submit" style="background:var(--danger);color:#fff;border-color:transparent;">Delete</button>
+                        </form>
+                        <% if (b.getStatus() != null && !"PAID".equalsIgnoreCase(b.getStatus().name())) { %>
+                        <form action="<%=ctx%>/dashboard/bills" method="post" style="display:inline">
+                            <input type="hidden" name="action" value="markPaid">
+                            <input type="hidden" name="id" value="<%=b.getId()%>">
+                            <button class="btn" type="submit">Mark Paid</button>
+                        </form>
+                        <% } %>
+                        <% } %>
+                    </td>
+                </tr>
+                <% } } %>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <% if (selected != null) { %>
+    <div class="panel" style="margin-top:1rem;">
+        <h3 style="margin-top:0;">Bill #<%= selected.getBillNo() %></h3>
+        <div class="scroll-wrap">
+            <table class="data-table">
+                <thead>
+                <tr>
+                    <th>SKU</th>
+                    <th>Item</th>
+                    <th style="width:80px;">Qty</th>
+                    <th style="width:100px;">Unit Price</th>
+                    <th style="width:100px;">Line Total</th>
+                </tr>
+                </thead>
+                <tbody>
+                <%
+                    List<BillLine> lines = selected.getLines();
+                    if (lines == null || lines.isEmpty()) {
+                %>
+                <tr><td colspan="5">No lines.</td></tr>
+                <%
+                    } else {
+                        for (BillLine l : lines) {
+                %>
+                <tr>
+                    <td><%= l.getSku()==null? "" : l.getSku() %></td>
+                    <td><%= l.getName()==null? "" : l.getName() %></td>
+                    <td><%= l.getQuantity() %></td>
+                    <td>Rs.<%= String.format("%.2f", l.getUnitPrice()) %></td>
+                    <td>Rs.<%= String.format("%.2f", l.getLineTotal()) %></td>
+                </tr>
+                <%
+                        }
+                    }
+                %>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <% } %>
+</section>


### PR DESCRIPTION
## Summary
- Implement BillsServlet to list bills, view details, and handle delete or mark-paid actions
- Add bills.jsp dashboard view showing bill headers, line items, and action buttons
- Extend navigation with link to Bills section

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b66842648326945d230c2ade5346